### PR TITLE
fix(协议解析): 兼容value为空字符串的情况

### DIFF
--- a/src/main/java/com/hyd/ssdb/conn/Connection.java
+++ b/src/main/java/com/hyd/ssdb/conn/Connection.java
@@ -103,10 +103,14 @@ public class Connection {
                         numSb.setLength(0);
                         status = 2;
                     } else if (status == 2) {
-                        dataCounter += 1;
-                        if (dataCounter >= dataLength) {
-                            status = 3;
-                            dataCounter = 0;
+                        if (dataLength == 0) {
+                            status = 0;
+                        } else {
+                            dataCounter += 1;
+                            if (dataCounter >= dataLength) {
+                                status = 3;
+                                dataCounter = 0;
+                            }
                         }
                     } else { // status == 3
                         status = 0;


### PR DESCRIPTION
**异常情况**
`2\nok\n0\n\n\n`

**正常情况**
`2\nok\n1\nA\n\n`

针对异常情况，status处于2时，读到倒数第二个\n的时候退出到 status = 3。其实这个时候 status 应该是 0。

正常情况下，status 从 2 --> 3 不是由 \n 退出的，而是由 dataCounter >= dataLength。 我看这样做事为了兼容 value 中有 \r\n 的字符。

我的修改是在status = 2 的时候，直接增加判断 dataLength 是否等于 0。 如果等于0 就直接退出到 status = 0。 从而兼容这种异常情况。

-----

不知道，还有没有更好的方案。

https://github.com/yiding-he/hydrogen-ssdb/issues/8